### PR TITLE
Make downloadFile function be able to download the whole file

### DIFF
--- a/src/main/java/com/pliablematter/cloudstorage/CloudStorage.java
+++ b/src/main/java/com/pliablematter/cloudstorage/CloudStorage.java
@@ -85,7 +85,7 @@ public class CloudStorage {
 		Storage.Objects.Get get = storage.objects().get(bucketName, fileName);
 		FileOutputStream stream = new FileOutputStream(file);
 		try {
-			get.executeAndDownloadTo(stream);
+			get.executeMediaAndDownloadTo(stream);
 		} finally {
 			stream.close();
 		}


### PR DESCRIPTION
I spend a couple of days reading documentation and API references, couldn't figure out why downloaded files are ~900 bytes.
Finally found proper method to download the whole file.
